### PR TITLE
letsencrypt certificate for osmose.openstreetmap.lu

### DIFF
--- a/hosts
+++ b/hosts
@@ -98,7 +98,7 @@ osm104.openstreetmap.fr letsencrypt_hosts=DNS:osm104.openstreetmap.fr,DNS:bano.o
 osm108.openstreetmap.fr letsencrypt_hosts=DNS:download.openstreetmap.fr,DNS:polygons.openstreetmap.fr,DNS:rawedit.openstreetmap.fr
 osm110.openstreetmap.fr letsencrypt_hosts=DNS:osm110.openstreetmap.fr,DNS:ae.openstreetmap.fr,DNS:dev.osmose.openstreetmap.fr
 osm113.openstreetmap.fr letsencrypt_hosts=DNS:owncloud.openstreetmap.fr
-osm117.openstreetmap.fr letsencrypt_hosts=DNS:osmose.openstreetmap.fr,DNS:beta.osmose.openstreetmap.fr
+osm117.openstreetmap.fr letsencrypt_hosts=DNS:osmose.openstreetmap.fr,DNS:beta.osmose.openstreetmap.fr,DNS:osmose.openstreetmap.lu
 osm124.openstreetmap.fr letsencrypt_hosts=DNS:buildbot.osmose.openstreetmap.fr
 
 [letsencrypt-proxy]


### PR DESCRIPTION
osmose.openstreetmap.lu also points towards osm117.

Since openstreetmap.lu has http strict transport security enabled for subdomains (HSTS includeSubDomains), osmose.openstreetmap.lu should have a letsencrypt certificate.

Thank you!