### PR TITLE
init /data path

### DIFF
--- a/shared/project-account.yml
+++ b/shared/project-account.yml
@@ -29,6 +29,9 @@
 - name: init group ${user}
   group: name={{ user }}
 
+- name: init /data path
+  file: path=/data state=directory
+
 - name: init /data/work/ path for ${user}
   file: path={{ work_dir }} state=directory owner={{ user }} group={{ user }}
 


### PR DESCRIPTION
when running overpass-api role, it fail to create /data/work because /data doesn't exist.
I create this small commit to create /data before /data/work