### PR TITLE
Ajout referer autorisé pour proxy-ign.openstreetmap.fr

### DIFF
--- a/roles/proxycache/files/nginx-osm24.openstreetmap.fr.site
+++ b/roles/proxycache/files/nginx-osm24.openstreetmap.fr.site
@@ -44,7 +44,7 @@ server {
 	rewrite ^/bdortho/(.*)/(.*)/(.*).jpg$ /kylmjz83kwrziwogye7jmq8h/wmts/?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=ORTHOIMAGERY.ORTHOPHOTOS&STYLE=normal&TILEMATRIXSET=PM&TILEMATRIX=$1&TILEROW=$3&TILECOL=$2&FORMAT=image%2Fjpeg break;
 
   location /kylmjz83kwrziwogye7jmq8h {
-    valid_referers *.openstreetmap.org/id opensolarmap.org www.mapcontrib.xyz www.cartes.xyz ;
+    valid_referers *.openstreetmap.org/id opensolarmap.org www.mapcontrib.xyz www.cartes.xyz cadastre.openstreetmap.fr ;
   	if ($http_user_agent ~ JOSM.*Java) {
   		set $valid 1;
   	}


### PR DESCRIPTION
Corrige https://github.com/osm-fr/infrastructure/issues/61
Cette PR ajoute le referer autorisé mais je ne sait pas si elle adresse le problème potentiel évoqué ci-dessous.

Attention, décalage potentiel entre Ansible et la config réelle. A vérifier avant déploiement au risque de faire une mise à jour à l'aveugle 
En effet, sur https://www.openstreetmap.org/edit#map=15/47.2088/-1.5555 la clé pour l'accès IGN semble être `94GjiyqD` (en inspectant l'onglet réseau du navigateur https://proxy-ign.openstreetmap.fr/94GjiyqD/bdortho/15/16244/11496.jpg) alors que le dépôt Ansible semble avoir une autre clé e.g `kylmjz83kwrziwogye7jmq8h`