### PR TITLE
Buildbot2 https+port

### DIFF
--- a/group_vars/cluster-ovh
+++ b/group_vars/cluster-ovh
@@ -129,6 +129,7 @@ proxy:
     websites: "buildbot2.osmose.openstreetmap.fr"
     target: "10.1.1.68"
     config_src: "nginx-site-buildbot2.j2"
+    redirect_to_https: True
   -
     logname: "id-editor"
     websites: "id-editor.openstreetmap.fr id.openstreetmap.fr"

--- a/roles/proxycache/templates/nginx-site-buildbot2.j2
+++ b/roles/proxycache/templates/nginx-site-buildbot2.j2
@@ -3,6 +3,14 @@ server {
     listen       [::]:80;
     server_name  {{ item.websites }};
 
+{% if item.redirect_to_https is defined and item.redirect_to_https %}
+    return 307 https://$host$request_uri;
+}
+
+server {
+    server_name  {{ item.websites }};
+
+{% endif %}
     include /etc/nginx/global.d/*.conf;
 
     #charset koi8-r;
@@ -23,7 +31,11 @@ server {
     proxy_set_header   X-Forwarded-Host  $host;
 
     location / {
+{% if item.target_port is defined %}
+        proxy_pass	http://{{ item.target }}:{{ item.target_port }};
+{% else %}
         proxy_pass	http://{{ item.target }};
+{% endif %}
         proxy_redirect  off;
    }
 
@@ -31,7 +43,11 @@ server {
         proxy_redirect  off;
         # proxy buffering will prevent sse to work
         proxy_buffering off;
-        proxy_pass http://{{ item.target }};
+{% if item.target_port is defined %}
+        proxy_pass	http://{{ item.target }}:{{ item.target_port }};
+{% else %}
+        proxy_pass	http://{{ item.target }};
+{% endif %}
     }
 
     # required for websocket
@@ -40,7 +56,11 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_pass http://{{ item.target }};
+{% if item.target_port is defined %}
+        proxy_pass	http://{{ item.target }}:{{ item.target_port }};
+{% else %}
+        proxy_pass	http://{{ item.target }};
+{% endif %}
         # raise the proxy timeout for the websocket
         proxy_read_timeout 6000s;
     }


### PR DESCRIPTION
buildbot2 : ajout support redirect_to_https et target_port dans le ttemplate et activation redirect_to_https 