### PR TITLE
osm312(comcommaker): Passage à Debian 10

### DIFF
--- a/host_vars/osm312.openstreetmap.fr/proxmox
+++ b/host_vars/osm312.openstreetmap.fr/proxmox
@@ -5,7 +5,7 @@ proxmox_var:
   ipv6: 2001:41d0:1008:1f65:1::312
   netif: {"net0": "name=eth0,bridge=vmbr0,ip=10.1.1.56/24,gw=10.0.0.26,ip6=2001:41d0:1008:1f65:1::312/80,gw6=2001:41d0:1008:1f65:1::26"}
   memory: 1024
-  ostemplate: debian-9.0-standard_9.5-1_amd64.tar.gz
+  ostemplate: debian-10-standard_10.5-1_amd64.tar.gz
   storage: "hdd-sdd"
   swap: 2048
   vmid: 312


### PR DESCRIPTION
J'ai avancé la remise en état de ComcomMaker, ce qui a impliqué notamment l'utilisation du [module sql de psycopg](https://www.psycopg.org/docs/sql.html#module-psycopg2.sql) pour éviter les injections SQL. Il n'est disponible que sur Debian 10 et supérieur.

Serait-ce possible de recréer la VM sous Debian 10 ? Je n'ai rien mis dessus, et je suppose que personne d'autre non plus donc elle peut être recrée de 0.

Merci :)