### PR TITLE
Accessibilité comcommaker

### DIFF
--- a/group_vars/cluster-ovh
+++ b/group_vars/cluster-ovh
@@ -118,10 +118,6 @@ proxy:
     websites: "educosm.openstreetmap.fr"
     target: "10.1.0.164"
   -
-    logname: "dev.comcommaker"
-    websites: "dev.comcommaker.openstreetmap.fr"
-    target: "10.1.1.56"
-  -
     logname: "dev.analyser"
     websites: "dev.analyser.openstreetmap.fr"
     target: "10.1.1.47"

--- a/host_vars/osm11.openstreetmap.fr/proxy
+++ b/host_vars/osm11.openstreetmap.fr/proxy
@@ -34,3 +34,8 @@ host_proxy:
     config_src: "nginx-site-osmose-jupyter.j2"
     redirect_to_https: True
     target_port: 8888
+  -
+    logname: "comcommaker"
+    websites: "comcommaker.openstreetmap.fr"
+    target: "192.168.0.179"
+    redirect_to_https: True

--- a/hosts
+++ b/hosts
@@ -296,7 +296,7 @@ osmose-jupyter.vm.openstreetmap.fr
 osmose-backend
 
 [gileri]
-osm26.openstreetmap.fr
+osm11.openstreetmap.fr
 comcommaker.vm.openstreetmap.fr
 
 [guillaumeamat]


### PR DESCRIPTION
Rends accessible (j'espère :wink:) comcommaker depuis son déplacement sur osm11 et debian10.

Je me suis permis de m'ajouter l'accès à osm11 au lieu de osm26 pour debug en cas de soucis, n'hésitez pas à me dire si ça va pas ou retirer le commit :)

Il faudra aussi changer l'enregistrement DNS comcommaker.openstreetmap.fr pour pointer sur osm11, et retirer dev.comcommaker.openstreetmap.fr.