### PR TITLE
Correction du nombre de CPU détecté et augmentation du checkpoint_timeout

### DIFF
--- a/roles/osmose-backend/defaults/main.yml
+++ b/roles/osmose-backend/defaults/main.yml
@@ -15,19 +15,19 @@ bgwriter_delay: 200
 bgwriter_lru_maxpages: 100
 bgwriter_lru_multiplier: 2.0
 
-max_worker_processes: "{% if ansible_processor_vcpus >= 10 %}{{ ansible_processor_vcpus - 2 }}{% else %}4{% endif %}"
-max_parallel_maintenance_workers: "{% if ansible_processor_vcpus > 8 %} 4 {% else %}2{% endif %}"
+max_worker_processes: "{% if ansible_processor_nproc >= 10 %}{{ ansible_processor_nproc - 2 }}{% else %}4{% endif %}"
+max_parallel_maintenance_workers: "{% if ansible_processor_nproc > 8 %} 4 {% else %}2{% endif %}"
 max_parallel_workers_per_gather: >-
- {% if ansible_processor_vcpus < 4 %}
+ {% if ansible_processor_nproc < 4 %}
  0
- {% elif ansible_processor_vcpus < 8 %}
+ {% elif ansible_processor_nproc < 8 %}
  1
- {% elif ansible_processor_vcpus < 16 %}
+ {% elif ansible_processor_nproc < 16 %}
  2
- {% elif ansible_processor_vcpus >= 16 %}
+ {% elif ansible_processor_nproc >= 16 %}
  4
  {% endif %}
-max_parallel_workers: "{% if ansible_processor_vcpus >= 4 %}{{ max_worker_processes | int - 2 }}{% else %}0{% endif %}"
+max_parallel_workers: "{% if ansible_processor_nproc >= 4 %}{{ max_worker_processes | int - 2 }}{% else %}0{% endif %}"
 
 # Ces paramètres sont revus par rapport à la valeur par défaut si on est sur du SSD
 effective_io_concurrency: 100

--- a/roles/osmose-backend/defaults/main.yml
+++ b/roles/osmose-backend/defaults/main.yml
@@ -49,7 +49,7 @@ shared_preload_libraries: "'pg_stat_statements'"
 session_preload_libraries: "'auto_explain'"
 
 wal_compression: "on"
-
+checkpoint_timeout: "30min"
 max_wal_size: "10GB"
 
 synchronous_commit: "on"

--- a/roles/osmose-backend/templates/postgresql-config
+++ b/roles/osmose-backend/templates/postgresql-config
@@ -88,7 +88,7 @@ wal_recycle = off                       # recycle WAL files
 wal_compression = {{ wal_compression }}
 
 # On espace un peu plus les checkpoints
-checkpoint_timeout = 15min
+checkpoint_timeout = {{ checkpoint_timeout }}
 checkpoint_completion_target = 0.9
 max_wal_size = {{ max_wal_size }}
 min_wal_size = 1GB


### PR DESCRIPTION
Il ne faut pas utiliser ansible_processor_vcpus (nombre de CPU sur le host) pour le nombre de CPU, mais ansible_processor_nproc (nombre de CPU sur le container).

Au passage augmentation du checkpoint_timeout à 30min avec possibilité de le surcharger.

Note: quelques paramètres bougent sur osm110 car sa mémoire a été doublée.

Voici le diff:

````diff
TASK [osmose-backend : configure postgresql] ************************************************************************************************************************************************************************************************
--- before: /etc/postgresql/13/main/conf.d/10-ansible-osmose.conf
+++ after: /home/anayrat/.ansible/tmp/ansible-local-68595auv16x_h/tmpaxsj_yb7/postgresql-config
@@ -2,9 +2,9 @@
 
 ssl = false
 
-shared_buffers = 131072
+shared_buffers = 262144
 
-maintenance_work_mem = 256MB
+maintenance_work_mem = 1GB
 
 work_mem = 64MB
 wal_buffers = 128MB
@@ -16,10 +16,10 @@
 bgwriter_lru_maxpages = 100
 bgwriter_lru_multiplier = 2.0
 
-max_worker_processes = 22
-max_parallel_maintenance_workers =  1 
-max_parallel_workers_per_gather =  1 
-max_parallel_workers = 1
+max_worker_processes = 4
+max_parallel_maintenance_workers = 2
+max_parallel_workers_per_gather =  0 
+max_parallel_workers = 0
 
 # Ces paramètres sont revus par rapport à la valeur par défaut si on est sur du SSD
 effective_io_concurrency = 100
@@ -27,7 +27,7 @@
 random_page_cost = 1.5
 
 # 2/3 de la RAM
-effective_cache_size = 174762
+effective_cache_size = 349525
 
 # L'estimation sur le JIT se prend un peu les pieds dans le tapis
 # et la requête suivante devient couteuse :
@@ -77,7 +77,8 @@
 wal_compression = on
 
 # On espace un peu plus les checkpoints
-checkpoint_timeout = 60min
+checkpoint_timeout = 30min
 checkpoint_completion_target = 0.9
 max_wal_size = 10GB
 min_wal_size = 1GB
+
 
changed: [osm110.openstreetmap.fr] => {"changed": true}
--- before: /etc/postgresql/13/main/conf.d/10-ansible-osmose.conf
+++ after: /home/anayrat/.ansible/tmp/ansible-local-68595auv16x_h/tmpob0tib7v/postgresql-config
@@ -67,7 +67,7 @@
 wal_compression = on
 
 # On espace un peu plus les checkpoints
-checkpoint_timeout = 15min
+checkpoint_timeout = 30min
 checkpoint_completion_target = 0.9
 max_wal_size = 10GB
 min_wal_size = 1GB
 
changed: [osmose-hivane1.openstreetmap.fr] => {"changed": true}
--- before: /etc/postgresql/13/main/conf.d/10-ansible-osmose.conf
+++ after: /home/anayrat/.ansible/tmp/ansible-local-68595auv16x_h/tmpn_ebb5nb/postgresql-config
@@ -67,7 +67,7 @@
 wal_compression = on
 
 # On espace un peu plus les checkpoints
-checkpoint_timeout = 15min
+checkpoint_timeout = 30min
 checkpoint_completion_target = 0.9
 max_wal_size = 10GB
 min_wal_size = 1GB
 
changed: [osmose-hivane2.openstreetmap.fr] => {"changed": true}
--- before: /etc/postgresql/13/main/conf.d/10-ansible-osmose.conf
+++ after: /home/anayrat/.ansible/tmp/ansible-local-68595auv16x_h/tmp25284j4s/postgresql-config
@@ -1,4 +1,4 @@
-# This file is managed by Ansible, do not edit directly
+# "This file is managed by Ansible, do not edit directly"
 
 ssl = false
 
@@ -16,10 +16,10 @@
 bgwriter_lru_maxpages = 100
 bgwriter_lru_multiplier = 2.0
 
-max_worker_processes = 22
+max_worker_processes = 18
 max_parallel_maintenance_workers =  4 
 max_parallel_workers_per_gather =  4 
-max_parallel_workers = 20
+max_parallel_workers = 16
 
 
 # 2/3 de la RAM
@@ -73,7 +73,7 @@
 wal_compression = on
 
 # On espace un peu plus les checkpoints
-checkpoint_timeout = 15min
+checkpoint_timeout = 30min
 checkpoint_completion_target = 0.9
 max_wal_size = 10GB
 min_wal_size = 1GB
 
changed: [osm213.openstreetmap.fr] => {"changed": true}
--- before: /etc/postgresql/13/main/conf.d/10-ansible-osmose.conf
+++ after: /home/anayrat/.ansible/tmp/ansible-local-68595auv16x_h/tmpycf2ul6x/postgresql-config
@@ -73,7 +73,7 @@
 wal_compression = on
 
 # On espace un peu plus les checkpoints
-checkpoint_timeout = 15min
+checkpoint_timeout = 30min
 checkpoint_completion_target = 0.9
 max_wal_size = 10GB
 min_wal_size = 1GB
 
changed: [osm211.openstreetmap.fr] => {"changed": true}
--- before: /etc/postgresql/13/main/conf.d/10-ansible-osmose.conf
+++ after: /home/anayrat/.ansible/tmp/ansible-local-68595auv16x_h/tmp8b4yxlvb/postgresql-config
@@ -73,7 +73,7 @@
 wal_compression = on
 
 # On espace un peu plus les checkpoints
-checkpoint_timeout = 15min
+checkpoint_timeout = 30min
 checkpoint_completion_target = 0.9
 max_wal_size = 10GB
 min_wal_size = 1GB
 
changed: [osmose-aquilenet.openstreetmap.fr] => {"changed": true}
--- before: /etc/postgresql/13/main/conf.d/10-ansible-osmose.conf
+++ after: /home/anayrat/.ansible/tmp/ansible-local-68595auv16x_h/tmpgsl4o6p7/postgresql-config
@@ -77,7 +77,7 @@
 wal_compression = on
 
 # On espace un peu plus les checkpoints
-checkpoint_timeout = 15min
+checkpoint_timeout = 30min
 checkpoint_completion_target = 0.9
 max_wal_size = 10GB
 min_wal_size = 1GB
 
changed: [osmose1.davintech.ca] => {"changed": true}
--- before: /etc/postgresql/13/main/conf.d/10-ansible-osmose.conf
+++ after: /home/anayrat/.ansible/tmp/ansible-local-68595auv16x_h/tmp34zeg3w3/postgresql-config
@@ -77,7 +77,7 @@
 wal_compression = on
 
 # On espace un peu plus les checkpoints
-checkpoint_timeout = 15min
+checkpoint_timeout = 30min
 checkpoint_completion_target = 0.9
 max_wal_size = 10GB
 min_wal_size = 1GB
 
changed: [osmose2.davintech.ca] => {"changed": true}
```