### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
             python3-pylama \
             yamllint
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: yamllint
         run: |


### PR DESCRIPTION
Github actions using Node 12 is deprecated.
This PR update checkout actions to v3
More information here -> https://github.blog/changelog/2023-07-17-github-actions-removal-of-node12-from-the-actions-runner/
No impact on workflow