### PR TITLE
osm2pgsql: Use of the rewritten account role

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ installed with:
 ### Adding a new user to a specific machine
 
 1. add the machine to file `hosts`, in the relevant section `[user]`
-1. if necessary, add the user to `roles/common/tasks/main.yml`, with the public ssh key in `public\_keys/<user>`
+1. if necessary, add the user to `group_vars/all/accounts.yml`, with the public ssh key in `public\_keys/<user>`
 1. launch following command:
     ```shell
-    ansible-playbook -l <hostname> common.yml --tags user_creation
+    ansible-playbook -l <hostname> accounts.yml
     ```
 
 ### Adding a service to a specific machine

--- a/hosts
+++ b/hosts
@@ -262,8 +262,8 @@ proxy.osmose.vm.openstreetmap.fr
 cluster-free
 
 [overpass-api]
-osm147.openstreetmap.fr overpass_version="v0.7.54" ssd="/ssd"
-osm148.openstreetmap.fr overpass_version="v0.7.54" ssd="/ssd"
+osm147.openstreetmap.fr overpass_version="v0.7.54"
+osm148.openstreetmap.fr overpass_version="v0.7.54"
 
 [proxmox-backup]
 osm26.openstreetmap.fr proxmox_backup_exclude="118 144 186 999" proxmox_backup_target="osm32.openstreetmap.fr:rpool/backups"
@@ -275,7 +275,7 @@ osm32.openstreetmap.fr proxmox_backup_host=true
 osm13.openstreetmap.fr renderd_layers=true
 osm166.openstreetmap.fr renderd_cyclosm=true
 renderd.th3.vm.openstreetmap.fr renderd_layers=true
-bzh202.vm.openstreetmap.fr renderd_bzh=true 
+bzh202.vm.openstreetmap.fr renderd_bzh=true
 
 [wireguard]
 proxy.ovh.vm.openstreetmap.fr wireguard_config=server

--- a/osm2pgsql.yml
+++ b/osm2pgsql.yml
@@ -3,4 +3,9 @@
   gather_facts: no
   become: yes
   roles:
+    - accounts
     - osm2pgsql
+  vars:
+    accounts__users:
+      osm2pgsql:
+        service: true

--- a/roles/accounts/tasks/account.yml
+++ b/roles/accounts/tasks/account.yml
@@ -12,7 +12,7 @@
 
 - name: Initialise folders for {{ user }}
   file:
-    path: /data/work/{{ user }}
+    path: "{{ file }}"
     state: directory
     group: "{{ user }}"
     owner: "{{ user }}"

--- a/roles/accounts/tasks/account.yml
+++ b/roles/accounts/tasks/account.yml
@@ -22,6 +22,14 @@
   loop_control:
     loop_var: file
 
+- name: Initialise {{ ssd }}/{{ user }} folder
+  file:
+    path: "{{ ssd }}/{{ user }}"
+    state: directory
+    group: "{{ user }}"
+    owner: "{{ user }}"
+  when: "service and ssd is defined"
+
 - name: Copy SSH key of user {{ user }}
   authorized_key:
     user: "{{ user }}"

--- a/roles/accounts/tasks/account.yml
+++ b/roles/accounts/tasks/account.yml
@@ -6,16 +6,21 @@
 - name: Set {{ user }} account
   user:
     group: "{{ user }}"
-    home: "/home/{{ user }}/"
+    home: "{{ workspace }}/{{ user }}"
     name: "{{ user }}"
     uid: "{{ uid }}"
 
-- name: Initialise /data/work/ folder for {{ user }}
+- name: Initialise folders for {{ user }}
   file:
     path: /data/work/{{ user }}
     state: directory
     group: "{{ user }}"
     owner: "{{ user }}"
+  loop:
+    - "/data/work/{{ user }}"
+    - "{{ workspace }}/{{ user }}"
+  loop_control:
+    loop_var: file
 
 - name: Copy SSH key of user {{ user }}
   authorized_key:
@@ -30,7 +35,7 @@
   copy:
     force: false
     src: "default{{ file }}"
-    dest: "/home/{{ user }}/{{ file }}"
+    dest: "{{ workspace }}/{{ user }}/{{ file }}"
     group: "{{ user }}"
     owner: "{{ user }}"
   loop:

--- a/roles/accounts/tasks/account.yml
+++ b/roles/accounts/tasks/account.yml
@@ -22,14 +22,6 @@
   loop_control:
     loop_var: file
 
-- name: Initialise {{ ssd }}/{{ user }} folder
-  file:
-    path: "{{ ssd }}/{{ user }}"
-    state: directory
-    group: "{{ user }}"
-    owner: "{{ user }}"
-  when: "service and ssd is defined"
-
 - name: Copy SSH key of user {{ user }}
   authorized_key:
     user: "{{ user }}"

--- a/roles/accounts/tasks/main.yml
+++ b/roles/accounts/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Set accounts
   include_tasks: account.yml
   vars:
+    service: "{{ item.value.service | default(false) }}"
     uid: "{{ item.value.uid | default(omit) }}"
     user: "{{ item.user }}"
     workspace: "{{ '/data/project' if item.value.service | default(false) else '/home' }}"

--- a/roles/accounts/tasks/main.yml
+++ b/roles/accounts/tasks/main.yml
@@ -2,9 +2,9 @@
 - name: Set accounts
   include_tasks: account.yml
   vars:
-    home_prefix: "{{ '/data/project' if item.value.service | default(false) else '/home' }}"
     uid: "{{ item.value.uid | default(omit) }}"
     user: "{{ item.user }}"
+    workspace: "{{ '/data/project' if item.value.service | default(false) else '/home' }}"
   loop: "{{ accounts__users | dict2items(key_name = 'user') }}"
   when: "item.user in group_names or (item.value.admin | default(false))"
 ...

--- a/roles/accounts/tasks/main.yml
+++ b/roles/accounts/tasks/main.yml
@@ -2,8 +2,9 @@
 - name: Set accounts
   include_tasks: account.yml
   vars:
+    home_prefix: "{{ '/data/project' if item.value.service | default(false) else '/home' }}"
+    uid: "{{ item.value.uid | default(omit) }}"
     user: "{{ item.user }}"
-    uid: "{{ item.value.uid }}"
   loop: "{{ accounts__users | dict2items(key_name = 'user') }}"
   when: "item.user in group_names or (item.value.admin | default(false))"
 ...

--- a/roles/osm2pgsql/tasks/main.yml
+++ b/roles/osm2pgsql/tasks/main.yml
@@ -15,8 +15,6 @@
 - name: ensure postgresql server is running
   service: name=postgresql state=started
 
-- include: ../../../shared/project-account.yml user=osm2pgsql
-
 - name: add sudoers to access osm2pgsql user
   copy: src=sudoers dest=/etc/sudoers.d/osm2pgsql-backend mode=0440 owner=root group=root validate='visudo -cf %s'
 

--- a/shared/project-account.yml
+++ b/shared/project-account.yml
@@ -11,11 +11,6 @@
     project_dir: "/data/project/{{ user }}"
     work_dir: "/data/work/{{ user }}"
 
-- name: set ssd_dir if there is ssd disk
-  set_fact:
-    ssd_dir: "{{ ssd }}/{{ user }}"
-  when: "ssd is defined"
-
 - name: Check if user exists
   action: shell /usr/bin/getent passwd {{ user }}
   register: user_exist
@@ -47,14 +42,6 @@
 
 - name: init /data/work/ path for ${user}
   file: path={{ work_dir }} state=directory owner={{ user }} group={{ user }}
-
-- name: create {{ ssd_dir }} dir
-  file:
-    path: "{{ ssd_dir }}"
-    state: directory
-    owner: "{{ user }}"
-    group: "{{ user }}"
-  when: "ssd_dir is defined"
 
 - name: copy default config files
   copy: force=no src="shared/files/default{{ item }}" dest="{{ project_dir }}/{{ item }}" owner={{ user }} group={{ user }}


### PR DESCRIPTION
This PR follows #97, merging the logic of all accounts into the `accounts` role.

This PR only changes `osm2pgsql` as an example, other services follow trivially.