### PR TITLE
osm2pgsql: Installation osm2pgsql venant des bullseye-backports

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -269,13 +269,13 @@
 - set_fact: install_apache=false
   when: install_apache is undefined
 
-- name: add buster-backports for monit
+- name: add backports
   apt_repository:
     filename: 'backports'
-    repo: 'deb http://ftp.debian.org/debian buster-backports main'
+    repo: 'deb http://ftp.debian.org/debian {{ ansible_distribution_release }}-backports main'
     state: present
     update_cache: yes
-  when: ansible_distribution_release == "buster"
+  when: ansible_distribution_release == "buster" or ansible_distribution_release == "bullseye"
 
 - name: install packages
   apt:

--- a/roles/osm2pgsql/tasks/main.yml
+++ b/roles/osm2pgsql/tasks/main.yml
@@ -12,6 +12,13 @@
       - osmosis
       - osmium-tool
 
+- name: install packages
+  apt:
+    pkg:
+      - osm2pgsql
+    default_release: bullseye-backports
+  when: ansible_distribution_release == "bullseye"
+
 - name: ensure postgresql server is running
   service: name=postgresql state=started
 


### PR DESCRIPTION
osm2pgsql sur bullseye-backports corrige un souci sur des ANALYZE lancés en trop lors de la mise à jour. Souci corrigé sur osm2pgsql 1.5.2.