### PR TITLE
Bump Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           cache: 'pip'
 


### PR DESCRIPTION
Github has planned to drop support of node JS 16 used by setup-python v4.
- https://github.com/actions/setup-python/releases/tag/v5.0.0
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/